### PR TITLE
Automatic numbering

### DIFF
--- a/app/views/statutes/statutes.html.twig
+++ b/app/views/statutes/statutes.html.twig
@@ -2,6 +2,7 @@
 
 {% block customstyles %}
 <link rel="stylesheet" href="/assets/css/toc.css" />
+<link rel="stylesheet" href="/assets/css/statutes.css" />
 {% endblock %}
 
 {% block menu %}
@@ -35,7 +36,7 @@
   </div>
 
   <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-    <div class="row" id="body_statutes">
+    <div class="row statutes" id="body_statutes">
       {{ body|raw }}
     </div>
   </div>

--- a/src/StatutesOnline/Controller/StatutesController.php
+++ b/src/StatutesOnline/Controller/StatutesController.php
@@ -33,7 +33,7 @@ class StatutesController {
 
     $language = $app['request']->get('language');
 
-    $md = file_get_contents("https://raw.githubusercontent.com/zefredz/ppbe-statutes-test/master/ppbe-statutes-{$language}.md");
+    $md = file_get_contents("assets/statutes/{$language}.md");
     // parse markdown
     $parser = new Markdown;
     // rewrite internal url

--- a/web/assets/css/statutes.css
+++ b/web/assets/css/statutes.css
@@ -1,0 +1,68 @@
+.statutes {
+  counter-reset: h2;
+}
+
+.statutes h2 {
+  counter-reset: h3;
+}
+
+.statutes h3 {
+  counter-reset: p h4;
+}
+
+.statutes h4 {
+  counter-reset: p h5;
+}
+
+.statutes h5 {
+  counter-reset: p;
+}
+
+.statutes ol {
+  list-style-type: lower-latin;
+  /*list-style-type: none;
+  margin-left: 0;
+  padding-left: 0;
+  counter-reset: li;*/
+}
+
+.statutes h2:before {
+  counter-increment: h2;
+  content: "Partie " counter(h2, upper-roman) ". ";
+}
+
+.statutes h3:before {
+  counter-increment: h3;
+  content: "Chapitre " counter(h2, upper-roman) "." counter(h3) ". ";
+}
+
+.statutes h4:before {
+  counter-increment: h4;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) ". ";
+}
+
+.statutes h5:before {
+  counter-increment: h5;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) "." counter(h5) ". ";
+}
+
+.statutes p:before {
+  counter-increment: p;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) "." counter(p) ". ";
+}
+
+/*.statutes li:before {
+  counter-increment: li;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) "." counter(p) "." counter(li, lower-latin) ". ";
+}*/
+
+.statutes h5:before {
+  counter-increment: h5;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) "." counter(h5) ". ";
+}
+
+.statutes h6:before {
+  counter-increment: h6;
+  content: counter(h2, upper-roman) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". ";
+}
+

--- a/web/assets/statutes/fr_be.md
+++ b/web/assets/statutes/fr_be.md
@@ -1,0 +1,590 @@
+# Statuts du Parti Pirate
+
+![logo](220px-Piratpartiet.svg.png)
+
+* Louvain-la-Neuve, 22.12.2012
+* Strombeek-Bever, 24.03.2013
+* Ghent, 29.06.2013
+* Ukkel - Uccle, 9.08.2014
+
+[TOC]
+
+## Partie I : Nom, Valeurs communes & Adhésion
+
+### Chapitre I.1. Nom
+
+Le Parti Pirate est une association de fait, créée pour une durée indéterminée.
+
+La dénomination de l’association est "Piratenpartij" en néerlandais, "Parti Pirate" en français, "Piratenpartei" en allemand, "Pirate Party" en anglais.
+
+L'association est une organisation politique.
+
+Le Parti Pirate et ses membres s'engagent à promouvoir les droits et libertés garantis par la Convention pour la protection des droits de l'homme et des libertés fondamentales du 4 Novembre 1950.
+
+
+### Chapitre I.2. Valeurs communes
+
+I.2.1 Les Pirates agissent dans le respect des principes suivants. Ces principes constituent les valeurs communes aux Pirates :
+
+#### I.2.1.1 Libertés
+
+I.2.1.1.1 La liberté individuelle va de pair avec la responsabilité collective, l'indépendance, l'autonomie et l'esprit critique.
+
+I.2.1.1.2 Les libertés fondamentales sur lesquelles les Pirates se concentrent plus particulièrement :
+
+I.2.1.1.3 Droit à la vie privée : Ce droit nécessite d’être renforcé et consiste d'abord en la libre disposition de son propre corps et ensuite en une série de droits garantis à la confidentialité: correspondance, données personnelles, états financiers, identité, localisation. Ces droits privés ne peuvent être violés que par des autorités compétentes sur des soupçons concrets, préalables et individuels d'un crime spécifique, commis, et sérieux (et non sur de simples présomptions).
+
+I.2.1.1.4 Liberté d’expression: Celle-ci ne consiste pas seulement à avoir le droit de dire ce que l’on veut, mais également celui d’être entendu, écouté et non-censuré et ce, quel que soit le sujet. Nous étendons la liberté d’expression à celle de pouvoir diffuser l’expression des autres sans limites. La liberté de conscience faisant partie intégrante de la liberté d'expression, les Pirates sont pour une séparation claire des religions et de l'Etat.
+
+#### I.2.1.2 Solidarité
+
+I.2.1.2.1 Les Pirates n’acceptent pas la lâcheté et l’indifférence en société, et agissent quand un courage moral est nécessaire. Les Pirates s’engagent pour une société solidaire où les forts défendent les faibles, indépendamment des territoires ou communautés.
+
+I.2.1.2.2 Les Pirates veulent rééquilibrer les relations entre générations.
+
+#### I.2.1.3 Cosmopolitisme
+
+I.2.1.3.1 Les Pirates font partie d’un mouvement mondial, ils ont plusieurs identités et ne sont rivés à aucune d'elles en particulier.
+
+I.2.1.3.2 Tous les modes de vie en communauté ont la même valeur.
+
+#### I.2.1.4 Démocratie
+
+I.2.1.4bis Les Pirates font la promotion d’un système politique réellement démocratique, c’est à dire d’un système politique ouvert, simple et transparent où le peuple gouverne le plus directement possible.
+
+I.2.1.4.1 Afin d’être effectif, un tel système nécessite l’existence une série de caractéristiques non exhaustives:
+
+I.2.1.4.2 Souveraineté du peuple: Les pouvoirs sont définis et détenus par l’ensemble des citoyens.
+
+I.2.1.4.3 Droit d’initiative: Droit de proposer des lois.
+
+I.2.1.4.4 Isonomie: Égalité Politique. Droit égal de tous les citoyens à exercer leurs droits politiques.
+
+I.2.1.4.5 Iségorie: Égalité devant le droit de parole. Droit pour chaque citoyen de prendre la parole et de faire des propositions dans les assemblées politiques. Quand un groupe membre est en désaccord avec la majorité, ce groupe a la liberté d'exprimer son point de vue.
+
+I.2.1.4.6 Séparation des pouvoirs: Tous les types de pouvoir (législatif, judiciaire, exécutif, médiatique, financier, monétaire, etc.) sont exercés au sein d’institutions distinctes.
+
+I.2.1.4.7 Mandat impératif: Tout mandaté exerce une mission définie dans son objet et sa durée et a l’obligation de s’y limiter. Ces mandats sont révocables et impliquent une reddition des comptes à l’échéance.
+
+I.2.1.4.8 Non-professionnalisation: La politique est l’affaire de tous les citoyens et non seulement de professionnels ou d’experts. Les débats et les lois doivent s’exprimer dans un langage qui reste compréhensible par le plus grand nombre.
+
+#### I.2.1.5 Créativité
+
+I.2.1.5.1 Les Pirates sont créatifs, curieux, et ne se satisfont pas du statu quo. Ils défient les systèmes, cherchent leurs points faibles, et trouvent des façons de les corriger. Les Pirates apprennent de leurs erreurs.
+
+#### I.2.1.6 Partage du savoir, de la technologie et de la culture
+
+I.2.1.6.1 Ceci doit être considéré comme un droit fondamental. Le système de droit d’auteur et de brevets en place actuellement limite artificiellement la circulation du savoir, des innovations technologiques, des logiciels et de la culture. En conséquence, les lois qui les définissent doivent être profondément réformées.
+
+#### I.2.1.7 Ecologisme
+
+I.2.1.7.1 Les Pirates luttent pour la pérennité des ressources naturelles et la libre circulation des ressources immatérielles. Ils n'acceptent aucun brevet sur le vivant.
+
+#### I.2.1.8 Equivalence
+
+I.2.1.8.1 Les Pirates entretiennent entre eux et avec les citoyens des relations d'égal à égal.
+
+I.2.1.8.2 Parce que chacun doit disposer des mêmes potentialités d'action, les Pirates font de l'inclusion numérique une priorité.
+
+I.2.1.8.3 Les Pirates sont attentifs à l'égalité réelle et effective entre les genres, sans préjugés.
+
+#### I.2.1.9 Objectivité
+
+I.2.1.9.1 Les Pirates préfèrent les décisions basées sur les sciences et les arguments plutôt que sur les justifications réglementaires, d'habitude ou des capacités d'un seul homme.
+
+I.2.1.9.2 Les Pirates sont positifs, ils préfèrent se battre pour que contre.
+
+### Chapitre I.3. Adhésion
+
+I.3.1 *Le montant de la cotisation des membres est libre et a renouveler par périodes de 1 an maximum. Le montant minimum est de 1 € symbolique, mais un montant plus substantiel est conseillé afin de participer aux frais de fonctionnement récurrents. Pour les frais ponctuels, des campagnes de levée de fonds sont organisées.*
+
+I.3.2 Le montant et les modalités de perception sont définis par l’Assemblée Générale.
+
+I.3.3 Le paiement de la cotisation est dû pour le Parti Pirate et aucune autre instance du Parti ne peut réclamer une cotisation supplémentaire.
+
+I.3.4 Un membre peut, sous certaines conditions, ne pas payer la cotisation.
+
+I.3.5 Pour devenir membre, il faut :
+
+1. être en règle de cotisation
+2. adhérer à certains principes
+3. n’être membre d’aucun groupe qui renierait les principes fondamentaux du Parti
+4. n’exercer aucun mandat pour le compte d’un autre parti politique.
+
+I.3.6 Pour devenir membre, un Pirate peut en faire la demande après de n’importe quel organe du parti, qui fera le relais de la Coreteam.
+
+I.3.7 Un membre du Parti Pirate est appelé un Pirate.
+
+I.3.8 Pour devenir membre, un Pirate doit fournir au minimum les informations suivantes : nom et prénom, code postal et une adresse e-mail. Si l’une de ces données change en cours d’année, il est attendu du pirate qu’il le communique à la Coreteam, qui relayera cette info aux instances concernées.
+
+I.3.9 Les données personnelles des membres (code postal, nom et e-mail) ne seront pas publiées et sont uniquement disponibles en interne sous certaines conditions.
+
+I.3.10 Tout membre est libre de démissionner par simple email aux instances concernées.
+
+I.3.11 Est réputé démissionnaire le membre qui, après au moins un rappel, ne s’est pas acquitté de sa cotisation après trente jours.
+
+I.3.12 Les membres de l’association de fait et leurs successeurs, à la fois pendant la vie et après la dissolution de l’association de fait, n’ont aucun droit personnel sur les actifs de l’association.
+
+I.3.13 L’exclusion ou la suspension d’un membre est prononcée par décision du Conseil du Parti.
+
+I.3.14 Est exclu d’office :
+
+1. tout membre figurant sur une liste de candidats à une élection concurrente
+2. tout élu mandataire politique qui, sans démissionner de son mandat ou sans accord de l’assemblée des membres concernés ou de la Coreteam, décide de siéger comme indépendant ou avec les membres d’un Groupe politique issus d’un autre parti politique.
+
+I.3.15 Les membres peuvent être candidats sur des listes non-officielles si aucune liste du Parti Pirate ne se présente dans ce district électoral. Toute collaboration avec des individus ou des groupes qui partagent les mêmes objectifs que le Parti Pirate est encouragée.
+
+I.3.16 Le Parti est composé de membres et de sympathisants.
+
+I.3.17 Un sympathisant est une personne qui marque sa volonté de soutenir le projet Pirate.
+
+I.3.18 Les droits et devoirs des sympathisants sont décrits dans un règlement adopté en Assemblée Générale.
+
+I.3.19 Les sympathisants n’ont pas le droit de vote au Conseil ou à l’Assemblée Générale.
+
+I.3.20 Les mandataires sont toutes les personnes qui remplissent un mandat au nom de leur affiliation au parti, soit par élection, soit par désignation ou suite à une conséquence directe d'une des deux.
+
+I.3.21 Les membres du personnel sont toutes les personnes qui travaillent comme salariés ou dans le cadre d'une mission rémunérée pour des asbl du parti, pour un membre d'une fraction parlementaire ou provinciale, un membre du parlement, un ministre, un secrétaire d'état ou un député permanent.
+
+I.3.22 Le nombre maximum de membres est illimité. Le minimum est fixé à 2. Un changement dans le fichier de membres pour une raison quelconque, tel que le décès, démission, révocation, ne peut pas conduire à la dissolution de l'association de fait.
+
+## Partie II : Structures
+
+### Chapitre II.1. Equipages
+
+II.1.1 L’équipage (aussi appelé Crew) est l'unité de base, une entité auto-organisée et locale du Parti Pirate. Un équipage s’inscrit dans une perspective locale (villes, villages, écoles, lieux de travail,..) afin de faciliter la proximité de ses membres tant sur une base relationnelle que géographique.
+
+II.1.2 L’équipage donne sa légitimité au Pirate. Chaque Pirate devrait, dès que possible, faire partie d'un équipage ou en fonder un.
+
+II.1.3 En aucun cas, une Crew ne peut prétendre représenter l'ensemble d'un territoire donné.
+
+II.1.4 Une Crew est composée de minimum trois Pirates.
+
+II.1.5 Au-delà de onze Pirates, la Crew a la possibilité de se scinder en deux nouveaux groupes. Si la Crew se réduit à moins de trois Pirates, ses membres doivent rejoindre une autre Crew ou trouver de nouveaux Pirates.
+
+II.1.6 Sans préjudice des présents statuts et dans le respect des objectifs généraux du Parti, la Crew décide de ses modes de fonctionnement et de financement ainsi que des actions qu’il mène.
+
+II.1.7 Dans chaque Crew, il y a un capitaine, un navigateur et, éventuellement, un trésorier.
+
+II.1.8 Les fonctions du Capitaine sont :
+
+1. de présider les réunions et représenter l’équipage vers le monde extérieur ;
+2. d’être le point de contact avec la Coreteam ;
+3. de s’assurer que son Equipage soit bien au courant des affaires du Parti et assurer une présence lors du Conseil des Capitaines.
+
+II.1.9 Les fonctions du Navigateur sont :
+
+1. coordonner les réunions ;
+2. actualiser la page wiki ;
+3. aider les nouveaux membres ;
+4. rédiger les PV de réunion ;
+5. la collecte des dates pour les réunions à venir et les communiquer clairement.
+
+II.1.10 Le trésorier est responsable de la gestion financière de l’équipage. Cette fonction est facultative dans un équipage.
+
+II.1.11 Un équipage est compétent pour :
+
+1. créer des liens entre les Pirates ;
+2. créer des liens entre les Pirates et la population ;
+3. organiser des réunions publiques;
+4. recruter, accueillir et encadrer les nouveaux membres ;
+5. lancer des projets ;
+6. construire un consensus autour d’idées et de projets politiques ;
+7. collecter des dons ou d'autres façons de faire la collecte de fonds, à condition de respecter la loi et seulement si c'est clairement fait au nom de la crew et non pas au nom du parti.
+
+II.1.12 Les devoirs d’un Equipage sont:
+
+1. choisir un nom qui lui est spécifique, afin de le reconnaître et d’éviter la confusion avec d’autres Équipages ;
+2. définir un point d’ancrage, un lieu où il se réunit régulièrement. Ce lieu doit être un lieu public, il peut être physique ou virtuel et doit être connu de tous et dans la mesure du possible à proximité du lieu de vie de ses membres ;
+3. se réunit au moins une fois par mois. Si une crew ne s’est plus réunie depuis six mois, elle est considérée comme inactive ;
+4. tenir et publier un rapport de chaque réunion ;
+5. tenir à jour une page wiki. Cette page doit contenir au minimum le nom de la Crew, les noms de ses membres, l’adresse de son Ancrage, la date de ses réunions et les rapports de ces réunions.
+
+II.1.13 Si une Crew décide d’ouvrir un compte bancaire, il doit désigner un trésorier et un trésorier-adjoint. Les fonds de la Crew doivent être gérés de façon ouverte et transparente, conformément aux présents statuts. Le Parti peut également ouvrir et gérer un compte bancaire au nom d’une Crew qui lui en fait la demande.
+
+II.1.14 Les Equipages peuvent travailler ensemble pour coordonner leurs actions sur une plus grande échelle géographique. Dans ce cas, ils forment une Flotte.
+
+II.1.15 Les postes sont renouvelés au plus tard tous les six mois ou dès qu’il y a destitution.
+
+### Chapitre II.2. Escouades
+
+II.2.1 Les Squads (aussi appelées escouades) sont les groupes de travail du parti.
+
+II.2.2 Les Squads ne sont pas liées à une ville ou région.
+
+II.2.3 Chaque pirate peut lancer un projet qui respecte les statuts et les buts généraux du parti.
+
+II.2.4 Les squads se composent d’au moins 3 pirates.
+
+II.2.5 Un Pirate peut faire partie d’autant de Squads qu’il le souhaite.
+
+II.2.6 Les seules conditions pour rejoindre une Squad sont l’intention et la capacité de participer.
+
+II.2.7 La Squad est le groupe de travail d’où provient les impulsions, les positions et les actions du Parti.
+
+II.2.8 Les Squads formalisent les impulsions, initiatives et idées fournies par les Pirates.
+
+II.2.9 Chaque pirate lançant un projet doit contacter l'escouade de coordination avec les informations suivantes : une description du projet et une personne de contact. L'escouade de coordination enregistre dans les faits le projet après avoir vérifié qu'il respecte les statuts et les valeurs du parti.
+
+II.2.10 Tout projet qui n'a pas été déclaré à l'escouade de coordination n'est pas pris en charge par le parti. Si le projet s'achève ou s'il est en pause, la personne de contact du projet doit en informer l'escouade de coordination.
+
+II.2.11 Pour valider le travail d’une Squad, les critères suivants doivent être rencontrés :
+
+1. le référencement (tout élément de proposition et/ou d’argumentation doit être appuyé d’une documentation) et la transparence (ladite documentation doit être accessible à tous) ;
+2. le travail doit être adopté par l’Assemblée Générale ou par une instance désignée par l’Assemblée générale ;
+3. la production passera par des outils de travail collaboratif (wiki, lqfb, jegouverne, forums, pad, irc, mumble,...) ;
+4. la Squad tient à jour une page wiki (infos, PV, …) et diffuse ses infos (mailing list, …) ;
+5. la Squad doit présenter un rapport de son activité au moins une fois par an ;
+6. la Squad a pris contact avec l’escouade de coordination.
+
+### Chapitre II.3. Coreteam
+
+#### II.3.A. Fonctions de la Coreteam
+
+II.3.A.1 Une instance de coordination est créée.
+
+II.3.A.2 Cette instance est un organe de concertation, d’échanges d’information et d’expériences.
+
+II.3.A.3 Cette instance porte le nom de Coreteam ou Amirauté.
+
+<del>II.3.A.4 Les membres de cette instance de coordination devraient être au minimum être bilingue FR/NL. La connaissance de l’anglais est aussi un avantage.</del>
+
+II.3.A.5 Sans préjudice des présents statuts et dans le respect des objectifs généraux du parti, l’instance de coordination nationale décide de son mode de fonctionnement et des actions qu’elle mène.
+
+II.3.A.6 Les membres de l’instance de coordination sont élus pour une période de un an.
+
+II.3.A.7 Si un membre de la Coreteam ne fait pas le travail correctement, elle peut se prononcer en interne pour une redistribution des tâches. Un membre de la Coreteam n’a pas l’exclusivité d’effectuer une tâche particulière.
+
+II.3.A.8 Les décisions internes de la Coreteam se prennent de préférence à l’unanimité, mais si ce n’est pas possible, avec au moins une majorité simple.
+
+II.3.A.9 La Coreteam se conforme au principe de subsidiarité. Cela signifie que le pouvoir est décentralisé à moins qu'il soit plus efficace de déléguer ce pouvoir à la Coreteam. Ce même principe s'applique aussi pour d'éventuels niveaux de décisions entre la Coreteam et les Crews.
+
+#### II.3.B. Rôles au sein de la Coreteam
+
+##### II.3.B.1 Integration :
+
+1. La Coreteam aide et assure le lien entre les pirates en Belgique.
+2. Elle assure la communication dans les deux sens avec les pirates belges.
+3. Elle représente le Parti Pirate dans les différentes régions. Sur bases  régulières, elle organise et participe à des évènements pirates, activités, etc, donne un aperçu des travaux des différents groupes de travail et squads.
+4. Elle sert de référence aux nouveaux équipage et les aide.
+5. La Coreteam fera en sorte que cette responsabilité soit effectuée de la manière la plus appropriée : un ou plusieurs membre(s) de la Coreteam, un membre du parti extérieur à la Coreteam, un professionnel, une Squad entière,...
+
+##### II.3.B.2 Trésorerie :
+
+1. Gèrer les finances nationales.
+2. Gèrer le compte du Parti Pirate belge.
+3. Pouvoir: La gestion financière journalière du parti, la bonne santé financière du parti en maintenant les comptes du parti, et la comptabilité du parti. Pour chaque versement reçu, informer les autres membres de la Coreteam responsables du traitement de ce paiement en y joignant la motivation.
+
+##### II.3.B.3 Coordination :
+
+1. Coordonner les décisions à prendre en tant que parti.
+2. Répertorier les activités des pirates belges.
+3. Supporter les équipages dans le développement, l'organisation et la participation aux événements pirates tels que les  assemblées, le suivi des travaux des différents groupes de travail et des squads.
+4. Aider les nouveaux équipages et nouvelles escouades à se former.
+5. La Coreteam fera en sorte que cette responsabilité soit effectuée de la manière la plus appropriée : un ou plusieurs membre(s) de la Coreteam, un membre du parti extérieur à la Coreteam, un professionnel, une Squad entière,...
+
+##### II.3.B.4 Le secrétaire :
+
+1. Faire un compte rendu des réunions de la coreteam et des activités administratives journalières du parti. Gérer la liste des membres.
+2. Gèrer la base de donnée des membres,  organiser le merchandising et gérer les cartes de membres du parti pirate.
+3. La coreteam est responsable de la logistique du parti et la gestion du webshop.
+
+##### II.3.B.5 La presse :
+
+1. Aider le plus tôt possible à interragir avec la presse, la préparation et l'élaboration d'un dossier de presse sur le parti, encourager une couverture médiatique aussi large que possible sur le parti.
+2. La Coreteam fera en sorte que cette responsabilité soit effectuée de la manière la plus appropriée : un ou plusieurs membre(s) de la Coreteam, un membre du parti extérieur à la Coreteam, un professionnel, une Squad entière,...
+
+##### II.3.B.6 International :
+
+1. Entretenir des rapports avec les Pirates des autres pays, assurer la représentation du parti dans les différentes instances internationales auxquelles le Parti Pirate participe, faire le compte rendu de ces échanges et organiser des débats à propos de ces instances.
+2. La Coreteam fera en sorte que cette responsabilité soit effectuée de la manière la plus appropriée : un ou plusieurs membre(s) de la Coreteam, un membre du parti extérieur à la Coreteam, un professionnel, une Squad entière,...
+
+##### II.3.B.6 IT :
+
+1. Assurer la maintenance de l'infrastructure IT et du site web, l'organisation et la mise en place de l'infrastructure nécessaire aux AG et la sécurisation des données du parti.
+2. La Coreteam fera en sorte que cette responsabilité soit effectuée de la manière la plus appropriée : un ou plusieurs membre(s) de la Coreteam, un membre du parti extérieur à la Coreteam, un professionnel, une Squad entière,...
+Toute décision de la coreteam doit être communiquée à tous les pirates.
+
+#### II.3.C. Composition de la coreteam
+
+II.3.C.1 Les 3 régions doivent être représentées: la Wallonie, la Flandre et Bruxelles.
+
+II.3.C.2 Un membre de la Coreteam est élu pour une période maximale de 18 mois.
+
+II.3.C.3 La Coreteam est renouvelée tous les six mois d’un tiers de ses membres.
+
+### Chapitre II.4. Support
+
+II.4.1 Un support technique et administratif est apporté aux Pirates.
+
+II.4.2 Ce support technique se matérialise au sein d’une instance spécialement dédiée : les escouades opérationnelles.
+
+II.4.3 Les personnes fournissant ce support s’engagent à:
+
+1. mettre en oeuvre la politique définie dans le projet pirate voté en Assemblée Générale, au service des Pirates ;
+2. ne pas pas prendre de décisions sur l’orientation idéologique du Parti ;
+3. publier très régulièrement et en détail l’ensemble de son activité et de s’assurer que tous les Pirates en sont clairement avertis.
+
+#### II.4.4 L'escouade de coordination :
+
+II.4.4.1 L'escouade de coordination a les compétences exclusives qui suivent :
+
+1. Gérer les courriels entrant de l'adresse de contact contact@pirateparty.be. «Gérer » signifie transférer à la bonne personne pour réponse.
+2. Maintenir une liste publique des équipages, y compris une personne de contact.
+3. Maintenir une liste publique des projets en cours, y compris une personne de contact.
+4. Convoquer tout pirate, escouade, équipage, coreteam ou représentant de projet afin de demander des informations sur leurs activités.
+
+II.4.4.2 L'escouade de coordination sert d' « oracle » pour les pirates. Cela signifie que chaque pirate ayant un besoin particulier ou une question peut la contacter. On attend ensuite d'elle qu'elle mette ce pirate en contact avec le pirate qui saura l'aider.
+
+#### II.4.5 L'escouade Finance :
+
+II.4.5.1 L'escouade Finance possède les compétences exclusives qui suivent:
+
+1. Mettre en oeuvre le budget approuvé par l'Assemblée Générale.
+
+II.4.5.2 Les revenus et dépenses doivent être visibles à n'importe quel moment et par n'importe qui.
+
+#### II.4.6 L'escouade AG :
+
+II.4.6. L'escouade AG organise les Assemblées Générales. L'escouade AG a les compétences exclusives qui suivent :
+
+1. S'assurer que le protocole de l'AG est correctement suivi.
+2. Rassembler toutes les propositions et amendements faits par les membres.
+3. Préparer tous les documents relatifs aux votes.
+4. S'assurer que ces documents sont traduits.
+5. Publier les statuts.
+6. Recueillir la motion de confiance.
+
+#### II.4.7 L'escouade IT :
+
+II.4.7.1 Les membres et seulement les membres de l'escouade IT ont accès aux serveurs du parti, à l'exception des membres de l'escouade Wiki, qui a un accès limité à ceux-ci, comme décrit dans la section correspondante.
+
+#### II.4.8 L'escouade Presse :
+
+II.4.8.1 La squad Presse a les compétences exclusives qui suivent :
+
+1. Parler au nom du parti dans la presse et les medias.
+2. Réagir à l'actualité en publiant des communiqués de presse.
+
+#### II.4.9 L'escouade Secrétariat :
+
+II.4.9.1 Les membres et seulement les membres de l'escouade Secrétariat ont accès à la base de données des membres du parti. L'escouade Secrétariat a les compétences exclusives qui suivent :
+
+1. S'assurer que le parti remplit toutes les conditions légales.
+2. Gérer les nouvelles adhésions et renouvellements des cotisations. Elle informe les nouveaux membres de leur adhésion effective et envoie des rappels personnels pour les cotisations.
+
+#### II.4.10 L'escouade Wiki :
+
+II.4.10.1 L'escouade Wiki s'occupe de la maintenance du wiki.
+
+II.4.10.2 Les membres et seulement les membres de la squad Wiki ont les droits d'administrateur sur le wiki.
+
+II.4.10.3 Les membres de la squad Wiki ont aussi accès à la plateforme wiki via un accès SSH spécial.
+
+### Chapitre II.5. Assemblée Générale
+
+II.5.1 Une voix peut être déléguée par procuration nominative à un et un seul Pirate.
+
+II.5.2 L’Assemblée Générale est compétente pour :
+
+1. définir les objectifs et options fondamentales et les traduire en programme politique ;
+2. définir le programme, l’orientation idéologique et l’organisation du Parti ;
+3. désigner le ou les liquidateurs de l’association de fait et déterminer leurs pouvoirs dans l’esprit des présents statuts ;
+4. élire tous les représentants au sein des instances fédérale du Parti;
+5. modifier les présents statuts ;
+6. élire les membres de la Cour d’Arbitrage ;
+7. prendre toute décision prévue par ou en vertu des présents statuts.
+
+II.5.3 L’Assemblée Générale est composée de tous les membres.
+
+II.5.4 L’Assemblée Générale se réunit au moins une fois par an.
+
+II.5.5 L’ordre du jour doit être envoyé à tous les membres six semaines avant la tenue de l’Assemblée Générale.
+
+II.5.6 L’Assemblée générale est convoquée extraordinairement :
+
+1. à la demande de 10% des membres ;
+2. à la demande de la Coreteam ;
+3. avant chaque élection.
+
+II.5.7 Tous les accords internationaux pris par le Parti Pirate ne sont valables qu'après  ratification par l'Assemblée générale. Cela comprend les relations avec le PPI et PPEU.
+
+### Chapitre II.6. X
+
+II.6.1 X se réunit en permanence en ligne et prend des décision démocratiques via un système choisi par elle. Le premier système choisi est “getOpinionated”. Cet organe peut changer de système à tout moment.
+
+II.6.2 Cet organe est composé de l’ensemble des membres du parti pirate.
+
+II.6.3 Cet organe est chargé de :
+
+1. proposer des modifications apportées au programme du parti.
+2. faire des propositions sur l'idéologie du parti.
+
+II.6.4 Cet organe dispose d’un droit d’évocation et d’interpellation vis à vis de la Coreteam et des membres de la Coreteam.
+
+II.6.5 Cet organe peut interpeller les membres du groupe, les ministres et secrétaires d’état et tous les mandataires politiques du parti concernant leurs actions publiques et les points de vues qu’ils s’expriment publiquement.
+
+## Partie III : Règlements divers
+
+### Chapitre III.1. Elus et Cumuls
+
+III.1.1 Les représentants pirates élus à une assemblée communale, provinciale, régionale ou fédérale s’engagent à :
+
+1. respecter le programme du Parti
+2. respecter le Traité européen des droits de l’homme
+3. justifier leurs décisions face aux autres Pirates
+4. être en ordre de cotisation
+5. participer aux réunions de leur Equipage
+6. démissionner si l’organisation concernée et la Coreteam estiment que l’élu ne satisfait pas aux engagements généraux et particuliers qu’il a pris en vue de sa désignation
+7. rendent compte de leur activité au moins à mi-mandat et en fin de mandat. Cette évaluation se fait notamment au regard de leurs obligations et engagements à l’égard de leurs électeurs.
+
+III.1.2 Les fonctions de la Coreteam sont incompatibles à tout niveau. Le cumul d’un mandat politique et une fonction dans la Coreteam n’est pas autorisé, sauf pour les mandats du conseil communal.
+
+III.1.3 Les représentants pirates élus à une assemblée communale, provinciale, régionale ou fédérale s’engagent à reverser une partie de son salaire : en fonction d’un barème selon les mandats, avec un minimum de 5% des revenus bruts pour tous les mandats.
+
+III.1.4 Sans porter préjudice aux autres dispositions statutaires, le droit de vote des mandataires est suspendu lors du non-paiement des contributions statutaires dans les trois mois qui suivent l’exigibilité de la dette. A partir du moment de la suspension de son droit de vote, la personne impliquée ne peut pas être candidat à aucune élection jusqu’au paiement de sa dette. Les mêmes règles sont d’application quand un comité de direction ne paie pas sa contribution. Dans un tel cas de figure, le droit de vote de tous leurs représentants / députés / mandataires leur est retiré.
+
+### Chapitre III.2. Votes et Majorité
+
+III.2.1 Toutes les décisions sont prises à la majorité simple, sauf si une majorité spéciale est exigée.
+
+III.2.2 Une majorité simple signifie plus de la moitié des suffrages exprimés, sans prendre en compte les abstentions. Une majorité spéciale comprend au moins le nombre d’or des suffrages exprimés :
+
+```[100*(V5-1)]/2 % ~ 61,8%``
+
+III.2.3 Les abstentions ne sont pas prises en compte pour le calcul des majorités.
+
+III.2.4 Les votes nuls ne seront jamais pris en compte.
+
+III.2.5 Si la moitié des suffrages exprimés (ou plus) sont des abstentions, le vote est considéré comme nul.
+
+III.2.6 Pour avoir l’unanimité, aucun pirate ne peut voter contre.
+
+III.2.7 Si une proposition n’obtient pas la majorité, elle est simplement rejetée.
+
+III.2.8 Motion de défiance :
+
+III.2.8.1 Une motion de défiance requiert un majorité extraordinaire des votes exprimés pour être validée.
+
+III.2.8.2 Il faut trois pirates pour invoquer une motion de défiance. Avant qu'un vote ait lieu, les raisons de la motion doivent être clairement exposées par les personnes qui y font appel.
+
+### Chapitre III.3. Formation des Listes
+
+III.3.1 Pour se présenter comme candidat aux élections communales, régionales, nationales of européennes, il faut être membre du parti pirate.
+
+III.3.2 Chaque candidat doit avoir la possibilité de défendre sa candidature.
+
+III.3.3 Les candidatures peuvent être déposées pour toutes les places sur la liste. Sur chaque candidature, il doit être mentionné la place souhaitée sur la liste.
+
+III.3.4 D'abord une liste des candidats est établie sur base de ces candidatures, indépendamment du/des lieu(x) où elle est d'application. Ensuite a lieu un vote d'approbation (approval voting) à propos de la liste de candidats ainsi qu'un classement Condorcet-Schulze. Tous les membres du Parti des Pirates qui habitent dans la zone justifiant leur présence sur la liste peuvent voter.
+
+III.3.5 Tous les candidats dans le classement qui n'ont pas obtenu la majorité simple lors du vote d'approbation (approval voting), sont rayés de la liste.
+
+III.3.6 Si plusieurs candidats se trouvent à la même place dans le classement, alors on désigne le plus haut classé par le jeu du pierre-papier-ciseaux, les yeux bandés.
+
+III.3.7 La liste est parcourue de haut en bas. Pour chaque place sur la liste, c'est le candidat le plus haut classé dans le classement et ayant posé sa candidature pour cette place qui l'obtient, s'il ne figure pas déjà dans la liste.
+
+III.3.8 Si lors du parcours de toutes les places sur la liste, il reste des candidats dans le classement qui ne figurent pas sur la liste, alors ceux-ci peuvent adapter encore une fois la place pour laquelle ils avaient posé leur candidature, après quoi on reprend à l'étape 3.
+
+III.3.9 Si lors du parcours de toutes les places sur la liste, il reste des places pour lesquelles il n'y a pas de candidat, alors tous les candidats classés sous cette place remontent d'une place dans la liste.
+
+III.3.10 Si après rédaction de la liste il y a des candidats qui se trouvent sur la liste mais qui ne souhaitent plus s'y trouver, alors on les retire de la liste et les candidats qui se trouvent en-dessous sur la liste montent d'une place.
+
+III.3.11 Si après ce processus, une liste a vu le jour mais qu'elle ne correspond pas au prescrit légal à cause de l'inégalité de représentation entre hommes et femmes sur la liste, alors les femmes remontent dans la liste et les hommes en bout de liste sont rayés, jusqu'à ce que la liste soit légalement conforme. Ensuite on retourne à l'étape 5. Si la liste est légalement en ordre, alors elle est définitive.
+
+III.3.12 Si tous les candidats qui ont posé leur candidature sont unanimement d'accord avec une autre méthode pour constituer la liste, ou sont unanimement d'accord avec la liste proposée, alors on peut dévier de cette méthode.
+
+### Chapitre III.4. Regroupement d’Equipages
+
+III.4.1 La Flotte est le regroupement temporaire et volontaire d’au moins deux Équipages, réunis autour d’un objectif commun et/ou d’un but précis. La décision de créer une Flotte doit faire l’objet d’une prise de décision formelle dans chacun des Equipages qui composeront la Flotte.
+
+III.4.2 Les membres de la Flotte sont les membres des Equipages qui la composent.
+
+III.4.3 La participation d’un Equipage à une Flotte doit faire l’objet d’un accord préalable de l’Equipage (opt-in).
+
+III.4.4 Sans préjudice des présents statuts et dans le respect des objectifs généraux du parti, la Flotte décide de ses modes de fonctionnement ainsi que des actions qu’elle mène.
+
+III.4.5 La Flotte est dissoute de facto dès que l’objectif est atteint et/ou qu’elle n’est plus composée que d’un seul Equipage.
+
+### Chapitre III.5 : Résolution de conflits
+
+#### III.5.1 Modération
+
+III.5.1.1 Les escouades responsables de la communication numérique du parti, ont le droit de modérer les canaux et de refuser, le cas échéant, l'accès à ces canaux. La modération et l'exclusion des canaux de diffusion ne devrait se faire qu'en cas de violation d'une charte d'utilisation des canaux de diffusion afin d'éviter toute accusation d'arbitraire. Celle-ci devra être définie ou adaptée d'une charte existante (par exemple une charte standard d'utilisation d'un forum, netiquette...)
+
+III.5.1.2 Celle-ci devrait être approuvée par l'AG.
+
+#### III.5.2 Commission de conciliation et de discipline
+
+III.5.2.1 L'autorité de l'Assemblée Générale doit être reconnue et respectée par tous les membres. Les personnes qui sapent l'autorité de l'Assemblée Générale, qui refusent de se soumettre aux décisions établies, ou qui par leur comportement ou attitude causent du trouble ou des dommages au parti, peuvent être suspendues de leurs fonctions.
+
+III.5.2.2 Les organes qui refusent de reconnaître l'autorité de l'Assemblée Générale, ou qui entreprennent des actions qui causent du trouble ou des dommages au parti, peuvent être suspendus de manière collective.
+
+III.5.2.3 La suspension d’organismes ou de membres est le fait d'une procédure de conciliation et de discipline, qui elle-même est initiée par 3 pirates au minimum à l'encontre de cet organe ou de ce membre.
+
+III.5.2.4 La Coreteam détermine les parties impliquées lors d'une procédure de conciliation et de discipline.
+
+III.5.2.5 La Coreteam peut suspendre une ou plusieurs des parties impliquées durant deux mois maximum ou jusqu’à ce que la procédure prenne fin, selon ce qui advient en premier.
+
+III.5.2.6 La Coreteam réunira un groupe de résolution de conflit, qui consiste en :
+
+* 5 membres du Parti Pirate tirés au sort parmi les membres présents durant la dernière AG. Si un pirate sélectionné décline l’invitation, un remplaçant doit être trouvé.
+* Les membres de la Coreteam et les personnes impliquées dans le conflit sont automatiquement exclues.
+* Le groupe de résolution de conflit contiendra au minimum 2 locuteurs de la langue des parties impliquées.
+
+III.5.2.7 Le groupe de résolution de conflit peut décider de ne pas traiter le conflit, dans la mesure où il est jugé sans importance ou non-pertinent.
+
+III.5.2.8 Le groupe de résolution de conflit doit d'abord essayer de résoudre le conflit par la médiation des parties impliquées. La médiation est considérée comme réussie si toutes les parties sont d’accord.
+
+III.5.2.9 Durant toute période de 6 mois précédant des élections politiques, une suspension ne peut être prononcée que sous l'approbation de la coreteam en fonction. Si elle n'a pas été prise, cette décision est reportée après lesdites élections.
+
+III.5.2.10 Toutes les plaintes et éléments en cours sont traités de manière publique et transparente, mais sous respect de la vie privée des personnes concernées.
+
+III.5.2.11 Le groupe de résolution de conflit peut, en dernier recours, décider de :
+
+* Réprimander formellement une ou plusieurs parties, aussi bien en interne (avec les parties impliquées) que publiquement au sein du parti.
+* Relever une partie ou plus de ses fonctions au sein du parti.
+* Suspendre une partie ou plus, pour une durée maximum de 12 mois.
+* Exclure une partie ou plus du Parti Pirate de Belgique et de n'importe quelle activité.
+
+III.5.2.12 Les décisions de la commission de conciliation et discipline sont prises à la majorité d’au moins 4 membres sur 5.
+
+III.5.2.13 Un membre auparavant exclu du parti fera part par écrit à l'Assemblée Générale de son souhait de réintégrer le parti. L'Assemblée Générale peut décider de s'occuper de l'affaire. Dans ce cas, elle entend le membre exclu et les éventuelles autres parties concernées et prend une décision.
+
+## Partie IV : Annexes
+
+### Prague Declaration, 17.04.2012
+
+The assembled European Pirates signed below agreed on the following:
+
+#### I.
+
+We intend to run in the elections to the European Parliament in the year 2014.
+
+#### II.
+
+We declare the intent to have a common election program included in the individual programs of the respective parties, to coordinate our election campaigns, to cooperate closely in the European Parliament on the realisation of our common program.
+
+#### III.
+
+The common program shall consist of components regarding European policies that have been approved by participating parties.
+
+Every participating party will be able to set forth its opinion and report the state of its procedure regarding every proposal.
+
+#### IV.
+
+We agree to establish a political party at European level [Regulation (EC) No 2004/2003 of the European Parliament and of the Council of 4 November 2003, as later amended].
+
+#### V.
+
+We propose this declaration for ratification to the competent bodies of the European Pirate Parties.
+
+### Paris Declaration, 20.02.2013
+
+Purpose of the organization is to represent the European Pirate movement towards the European institutions and to work in the interest of its members by, amongst other things:
+
+* Facilitating coordination and cooperation between its members.
+* Assisting its members to promote the Pirate movement in Europe.
+* Taking as its principles the Pirate manifesto, as will be annexed to the statutes.
+* Functioning as a link between European Pirate Parties and Pirate MEPs.
+* Encouraging and supporting its members in organizing events focused on European topics

--- a/web/assets/statutes/nl_be.md
+++ b/web/assets/statutes/nl_be.md
@@ -1,0 +1,579 @@
+# Statuten van Piratenpartij
+
+![logo](220px-Piratpartiet.svg.png)
+
+* Louvain-la-Neuve, 22.12.2012
+* Strombeek-Bever, 24.03.2013
+* Ghent, 29.06.2013
+* Ukkel - Uccle, 9.08.2014
+
+[TOC]
+
+## Deel I : Naam, gemeenschappelijke Waarden & Lidmaatschap
+
+### Hoofdstuk I.1. Naam
+
+I.1.1 De vereniging de Piratenpartij is een feitelijke vereniging, opgericht voor onbepaalde duur.
+
+I.1.2 De naam van de vereniging is "Piratenpartij" in het Nederlands, "Parti Pirate" in het Frans, "Piratenpartei" in het Duits, "Pirate Party" in het Engels.
+
+I.1.3 De vereniging is een politieke organisatie.
+
+I.1.4 De Piratenpartij en haar leden verbinden er zich toe de rechten en vrijheden, zoals gewaarborgd door het Verdrag tot bescherming van de Rechten van de Mens en de Fundamentele Vrijheden van 4 november 1950, te bevorderen.
+
+### Hoofdstuk I.2. Gemeenschappelijke Waarden
+
+I.2.1 De piraten handelen volgens de volgende principes, die de gemeenschappelijke piratenwaarden vormen:
+
+#### I.2.1.1. Vrijheden
+
+I.2.1.1.1 Individuele vrijheid hoort bij een collectieve verantwoordelijkheid, onafhankelijkheid, autonomie en kritisch oordeel.
+
+I.2.1.1.2. Piraten focussen in het bijzonder op deze fundamentele vrijheden:
+
+I.2.1.1.2.1 Recht op privacy: Dit recht moet sterker afgedwongen worden. Het bestaat uit, om te beginnen, het vrij beschikken over je eigen lichaam. Het wordt dan uitgebreid naar een reeks rechten op confidentialiteit: correspondentie, persoonlijke data, financiële situatie, identiteit, locatie. Deze rechten kunnen enkel gebroken worden door de bevoegde autoriteiten, gebaseerd op eerdere, solide, individu-specifieke verdenkingen, in tegenstelling tot enkel vermoedens.
+
+I.2.1.1.2.2 Recht op vrije meningsuiting: vrije meningsuiting is meer dan enkel het recht om vrij je mening te uiten. Het is ook het recht om gehoord te worden, en om niet gecensureerd te worden op om het even welk onderwerp. We breiden vrijheid van meningsuiting uit tot het kopiëren van de mening van anderen, zonder grenzen. Vrijheid van religie is ook een belangrijk deel van de vrije meningsuiting. Piraten zijn voor een duidelijke en strikte scheiding tussen kerk en staat.
+
+#### I.2.1.2. Solidariteit :
+
+I.2.1.2.1. Piraten kunnen geen lafheid of onverschilligheid aanvaarden in een samenleving. Ook wanneer moed nodig is, gaan ze in de bres springen. Piraten engageren zich om een maatschappelijk model te promoten gebaseerd op solidariteit, op de sterken die de zwakken verdedigen, onafhankelijk van territoria of gemeenschappen.
+
+I.2.1.2.2. Piraten willen de balans tussen de generaties herstellen.
+
+#### I.2.1.3. Cosmopolitisme :
+
+I.2.1.3.1. Piraten zijn een deel van een wereldwijde beweging. Ze zitten niet vast aan één van hun vele identiteiten.
+
+I.2.1.3.2. Alle samenlevingsvormen moeten gelijkwaardig zijn.
+
+I.2.1.4. Democratie : Piraten promoten een echt democratisch politiek systeem: dat is een open, simpel en transparant systeem die de mensen de kans heeft om zo direct als mogelijk te regeren.
+
+Om effectief te kunnen zijn, moet zo'n systeem minstens de volgende lijst van karakteristieken hebben.
+
+I.2.1.4.1. Soevereiniteit van het volk: De macht wordt gedefinieerd als uitgeoefend door alle burgers.
+
+I.2.1.4.2. Initiatiefrecht: Het recht om wetten voor te stellen.
+
+I.2.1.4.3. Isonomia: Politieke gelijkheid, iedere burger moet dezelfde kansen hebben om zijn politieke rechten uit te oefenen.
+
+I.2.1.4.4. Isegoria: Gelijkheid om zichzelf uit te drukken. Iedere burger heeft het recht om zichzelf uit te drukken en om voorstellen in te dienen bij politieke instanties. Wanneer een groep leden het oneens zijn met de meerderheid van de partij kunnen zij vrij hun standpunt verkondigen.
+
+I.2.1.4.5. Scheiding van de macht: alle types van macht (wetgevend, rechterlijk, uitvoerend, media, financieel, etc...), worden uitgeoefend binnen verschillende instituten.
+
+I.2.1.4.6. Imperatief mandaat: Alle gemandateerde officials voeren een opdracht uit de duidelijk gedefinieerd is in termen van inhoud en duur en moet zich daar aan houden. Deze mandaten zijn herroepbaar en impliceren volledige aansprakelijkheid op hun voorwaarden.
+
+I.2.1.4.7. Anti-professionalisatie: Politiek is een burgerlijke zaak, en niet enkel voor professionals of experten. Debatten en wetten moeten uitgedrukt worden in een taal die verstaanbaar is voor zo veel mogelijk mensen.
+
+#### I.2.1.5. Creativiteit:
+
+I.2.1.5.1 Piraten zijn creatief, nieuwsgierig en niet tevreden met de status quo. Ze dagen het systeem uit, zoeken haar zwakheden en zoeken en vinden manieren om die te corrigeren. Piraten leren van hun fouten.
+
+#### I.2.1.6. Sharing  van kennis, technologie en cultuur:
+
+I.2.1.6.1 dit moet gezien worden als een fundamenteel recht.
+De huidige wetten op copyright en patenten leggen artificiële grenzen aan de stroom van kennis, technologische innovatie, software en cultuur. Dus copyright en patenten hebben radicale hervormingen nodig.
+
+#### I.2.1.7 Ecologisch :
+
+I.2.1.7.1 Piraten zorgen voor een behoud van natuurlijke bronnen en willen een vrije stroom van virtuele bronnen. Ze aanvaarden geen eigendom van leven.
+
+#### I.2.1.8. Gelijkwaardigheid:
+
+I.2.1.8.1. Piraten onderhouden banden onderling zijn gelijkwaardigen onder elkaar en tussen burgers.
+
+I.2.1.8.2. Omdat iedereen hetzelfde potentieel heeft, maakt de Piraten van digitale inclusie een prioriteit.
+
+I.2.1.8.3. Piraten zijn aandacht naar werkelijke, echte gelijkwaardigheid tussen genders, zonder hokjesdenken.
+
+#### I.2.1.9 Objectiviteit:
+
+I.2.1.9.1. Piraten verkiezen beslissingen gebaseerd op wetenschap en op argumenten, eerder dan redenen gebaseerd op wetgeving, gewoonten of individuele mogelijkheden.
+
+I.2.1.9.2. Piraten zijn positief, we zijn liever ergens voor, dan tegen.
+
+### Hoofdstuk I.3. Lidmaatschap
+
+I.3.1 Het lidgeld is vrij en minstens om het jaar te vernieuwen. Het minimale bedrag is een symbolische euro, maar een substantieel hoger bedrag is aangeraden zodat we kunnen deelnemen aan de terugkerende kosten. Voor kosten worden ook fondsen wervingscampagnes georganiseerd.
+
+I.3.2 Het bedrag en de modaliteiten worden vastgelegd door de Algemene Vergadering.
+
+I.3.3 De betaling van het lidgeld wordt aan de Piratenpartij gedaan en geen enkele andere instantie van de Partij kan bijkomend lidgeld eisen.
+
+I.3.4 Een lid kan, onder bepaalde omstandigheden, zijn lidgeld niet hoeven te betalen.
+
+I.3.5 Om lid te worden, moet je:
+
+a) in orde zijn met het lidgeld
+b) akkoord gaan met een aantal principes
+c) geen lid zijn van een groep die in tegenstelling is met een aantal fundamentele principes van de partij
+d) geen enkel mandaat uitvoeren voor een andere politieke partij.
+
+I.3.6 Om lid te worden kan een piraat de vraag stellen aan om het even welk orgaan van de partij, die de vraag moet doorgeven aan het Coreteam.
+
+I.3.7 Een lid van de piratenpartij heet een “Piraat”.
+
+I.3.8 Om lid te worden, moet een Piraat minimaal de volgende informatie doorgeven: naam en voornaam, postcode en emailadres. Indien een van deze gegevens verandert in de loop van het jaar, wordt van het lid verwacht dat hij dit doorgeeft aan het coreteam, die de informatie doorgeeft aan de bevoegde organen.
+
+I.3.9 De persoonlijke gegevens van leden (postcode, naam en email) worden niet gepubliceerd en zijn enkel intern beschikbaar onder bepaalde voorwaarden.
+
+I.3.10 Ieder lid kan zich uitschrijven met een simpele mail aan de bevoegde instanties.
+
+I.3.11 Wordt uitgeschreven als lid, ieder die na minstens een oproep, zijn lidgeld niet betaald heeft na dertig dagen.
+
+I.3.12 De leden van de FV en hun rechtsopvolgers hebben zowel tijdens het bestaan als na de ontbinding van de feitelijke vereniging, geen enkele persoonlijke aanspraak op het vermogen van de FV.
+
+I.3.13 De uitsluiting of schorsing van een lid wordt uitgesproken door een beslissing van de partijraad.
+
+I.3.14 Wordt automatisch uitgesloten:
+
+a) ieder lid op een andere kandidatenlijst dan de lijst van de Piratenpartij bij dezelfde verkiezingen
+b) iedere verkozen mandataris die, zonder af te zien van zijn mandaat of zonder akkoord van de algemene vergadering of het coreteam, beslist om te zetelen als onafhankelijke of met de leden van een politieke groep van een andere politieke partij.
+
+I.3.15 Leden mogen kandidaat zijn op niet-officiële lijsten indien er in dat kiesdistrict geen lijst van de Piratenpartij aanwezig is. Samenwerking met individuen of groeperingen die dezelfde doelen nastreven als de Piratenpartij wordt aangemoedigd.
+
+I.3.16 De Partij bestaat uit leden en sympathisanten.
+
+I.3.17 Een sympathisant is een persoon die heeft bevestigd de wil te hebben om het piratenproject te ondersteunen.
+
+I.3.18 De rechten en plichten van sympathisanten worden beschreven in een reglement aangenomen door de algemene vergadering.
+
+I.3.19 Sympathisanten hebben geen stemrecht in raden of in de algemene vergadering.
+
+I.3.20 Mandatarissen zijn alle personen die uit hoofde van hun lidmaatschap van de partij een mandaat vervullen, hetzij door verkiezing, hetzij door aanwijzing, hetzij rechtstreeks voortvloeiend uit één van beide.
+
+I.3.21 Personeelsleden zijn alle personen die werken in loondienst of in bezoldigde opdracht van de partij-v.z.w.’s, een parlementaire of provinciale fractie, een parlementslid, een minister, een staatssecretaris of een bestendig afgevaardigde.
+
+I.3.22 Het maximum aantal leden is onbeperkt. Het minimum is vastgesteld op 2. Een wijziging van het ledenbestand om welke reden ook, zoals overlijden, ontslag, afzetting, kan niet leiden tot ontbinding van de FV.
+
+## Deel II : Structuren
+
+### Hoofdstuk II.1. Crews
+
+II.1.1 Een crew is de basiseenheid. Het is een lokale entiteit die zichzelf organiseert. Een Crew vindt plaats met lokale perspectieven (steden, dorpen, scholen, werkplaatsen,…) om zo dicht mogelijk bij haar leden te zijn.
+
+II.1.2 Het is de crew die een piraat legitiem maakt en dus, moet elke Piraat, zo vroeg mogelijk, zich aansluiten tot een crew of er één opstarten.
+
+II.1.3 In ieder geval, een Crew kan niet doen alsof ze een gegeven territorium vertegenwoordigt.
+
+II.1.4 Een crew bestaat uit minimaal drie piraten.
+
+II.1.5 Bij meer dan elf piraten heeft een crew de mogelijkheid om te splitsen in twee nieuwe crews. Als ze vermindert tot minder dan 3 piraten, moeten de leden bij een andere Crew gaan of nieuwe piraten vinden.
+
+II.1.6 Onverminderd de huidige statuten en binnen het respect van de algemene doelen van de partij, beslist een Crew over haar eigen manier van werken en financiering zoals haar acties vereisen.
+
+II.1.7 In iedere Crew heb je een kapitein, een navigator en eventueel een schatbewaarder.
+
+II.1.8 De functies van de Kapitein zijn:
+a) vergaderingen voorzitten en de crew vertegenwoordigen voor de buitenwereld;
+b) het aanspreekpunt zijn van de Crew voor het Coreteam.
+c) ervoor zorgen dat de leden van hun Crew goed op de hoogte zijn van de zaken van de partij en hun leden vertegenwoordigen in de Raad van de Kapiteinen.
+
+II.1.9 De functies van de navigator zijn:
+a) het coördineren van de vergaderingen;
+b) verantwoordelijk zijn voor het up-to-date houden van de wiki-pagina;
+c) nieuwe leden helpen;
+d) verantwoordelijk zijn voor notulen op de vergadering;
+e) vastleggen van data voor de komende vergaderingen en deze duidelijk communiceren.
+
+II.1.10 De schatbewaarder is verantwoordelijk voor het financieel beheer van een crew. Deze functie is optioneel binnen een Crew.
+
+II.1.11 Een crew kan:
+a) linken creëren tussen Piraten;
+b) linken creëren tussen Piraten en de bevolking;
+c) organiseren van openbare bijeenkomsten;
+d) rekruteren, ontvangen en omkaderen van nieuwe leden;
+e) projecten lanceren;
+f) een consensus zoeken rond ideeën en politieke projecten.
+g) giften verzamelen of op andere manieren aan fondsenwerving doen, binnen hetgeen wettelijk is toegestaan, enkel indien dit duidelijk in naam van de Crew en niet in naam van de partij gebeurt.
+
+II.1.12 Een crew moet:
+a) een naam kiezen die op hen specifiek van toepassing lijkt. Dit dient voor herkenning en om verwarring te voorkomen met andere Crews;
+b) een ankerplaats hebben, een plaats waar ze regelmatig verzamelt. Die plaats moet een openbare ruimte zijn, ze mag zowel fysiek als virtueel zijn en moet door iedereen gekend zijn;
+c) verzamelt zich op die plaats minstens één keer per maand. Als een Crew al 6 maanden niet meer bijeen is gekomen, wordt ze als inactief beschouwd. ;
+d) een rapport opstellen en publiceren van iedere vergadering;
+e) zijn wiki-pagina up-to-date houden. Deze pagina moet minimaal de naam van de crew, de namen van zijn leden, het adres van zijn dok, de datum van zijn vergaderingen en de verslagen van de vergaderingen bevatten.
+
+II.1.13 Indien een Crew ervoor kiest om een nieuwe bankrekening te openen, moet ze een schatbewaarder aanwijzen en een hulp-schatbewaarder. De fondsen van de Crew moeten op een open en transparante manier beheerd worden, conform met de statuten. De partij mag ook een bankrekening openen en beheren in naam van een Crew indien ze dat wenst.
+
+II.1.14 Crews kunnen samenwerken en hun acties coördineren op een hoger geografisch niveau. In dat geval vormt ze een Vloot.
+
+II.1.15 De posten worden vernieuwd ten laatste iedere zes maanden of bij ieder ontslag.
+
+### Hoofdstuk II.2. Squads
+
+II.2.1 Squads zijn de werkgroepen van de partij.
+
+II.2.2 Squads zijn niet gelinkt aan een stad of regio.
+
+II.2.3 Elke piraat kan een project dat de statuten en de algemene doelen van de partij respecteert starten.
+
+II.2.4 Squads bestaan uit minstens 3 piraten.
+
+II.2.5 Een piraat kan deel uitmaken van zoveel squads als hij wil.
+
+II.2.6 De enige voorwaarden om lid te worden van een squad zijn de intentie en de mogelijkheid om mee te werken.
+
+II.2.7 Een squad is een werkgroep waaruit de impulsen, posities en acties van de partij komen.
+
+II.2.8 De squad is een formalisatie van de vooruitgang, initiatieven en ideeën geleverd door de Piraten.
+
+II.2.9 Elke piraat die een project start moet de coördinatie-squad contacteren met de volgende informatie: een beschrijving van het project en een contactpersoon. De coördinatie-squad registreert het project formeel na verificatie dat het de statuten en de waarden van de partij respecteert.
+
+II.2.10 Elk project dat niet aangegeven werd aan de coördinatie-squad is niet onderschreven door de partij. Als het project beëindigd of in stand-by is, moet de contactpersoon van het project dit melden aan de coördinatie-squad.
+
+II.2.11 Opdat het werk van een squad geldig zou zijn, moet het aan de volgende voorwaarden voldoen:
+
+a) referenties (ieder element van een voorstel en/of een argumentatie moet verwijzen naar documentatie) en transparantie (de documentatie moet voor iedereen beschikbaar zijn) ;
+b) het werk moet aanvaard worden door de algemene vergadering of door een door de algemene vergadering aangewezen instantie;
+c) de productie gebeurt met collaboratieve werkmiddelen (wiki, lqfb, jegouverne, forums, pas, irc, mumble, ...) ;
+d) een squad onderhoudt een wikipagina (infos, PV, ...) en verspreidt deze info (mailing list, ...);
+e) Een squad moet minstens één keer per jaar verslag uitbrengen over zijn activiteiten;
+f) de squad deelt het bestaan van de squad mee aan de coordinatie-squad.
+
+### Hoofdstuk II.3. Coreteam
+
+#### II.3.A. Functies van het Coreteam
+
+II.3.A1 Een coördinatie instantie is gecreëerd.
+
+II.3.A2 Deze instantie is een orgaan van samenwerking, van uitwisseling van informatie en ervaringen.
+
+II.3.A3 Die instantie draagt de naam Coreteam of Admiraliteit.
+
+<del>II.3.A4 De leden van die coördinatie-instantie moeten liefst minimaal tweetalig NL-FR zijn. De kennis van Engels is ook een voordeel.</del>
+
+II.3.A5 Onverminderd de statuten en met respect voor de algemene doelen van de partij, beslist de coördinatie-instantie intern over haar werking en de acties die ze uitvoert.
+
+II.3.A6 De leden van de coördinatie-instantie worden verkozen voor een periode van een jaar.
+
+II.3.A7 Indien leden van het Coreteam hun werk niet naar behoren uitvoeren, dan kan het Coreteam intern beslissen over een herverdeling van taken. Een lid van het Coreteam heeft niet het alleenrecht op het uitvoeren van een bepaalde taak.
+
+II.3.A8 Interne beslissingen van het Coreteam gebeuren bij voorkeur met unanimiteit, maar indien dit niet mogelijk zou zijn, met minstens een gewone meerderheid.
+
+II.3.A9 Het Coreteam volgt het principe van de subsidiariteit. Dit houdt in dat een bevoegdheid decentraal wordt uitgeoefend tenzij het doeltreffender is om deze bevoegdheid op het niveau van het Coreteam uit te oefenen. Ditzelfde principe geldt ook voor eventuele intermediaire beslissingsniveaus tussen het Coreteam en de crews.
+
+#### III.3.B. Rollen van het coreteam
+
+##### II.3.B1 Integratie:
+
+Het Coreteam helpt en verbindt de piraten in België. Het Coreteam communiceert met de Belgische piraten in twee richtingen en zorgt voor de vertegenwoordiging van de Piratenpartij in de verschillende regio's. Het op regelmatige basis organiseren en bijwonen van Piratenevents, activiteiten, en dergelijke, het overzicht over het werk van de verschillende squads en werkgroepen. Het Coreteam is een referentie voor en helpt nieuwe crews.
+
+Het Coreteam ziet toe dat deze verantwoordelijkheid wordt uitgevoerd op een manier die hun het meest geschikt lijkt: Eén/enkele van hen, een partijlid extern aan het Coreteam, een professioneel iemand, een hele squad ...
+
+##### II.3.B2 De schatbewaarder:
+
+a) beheert de nationale financiën.
+b) beheert de gemeenschappelijke rekening van de Belgische Piratenpartij.
+c) Bevoegdheid: De dagelijkse financiële verantwoordelijkheid over de partij, de financiële leefbaarheid van de partij door het onderhouden van de rekeningen van de partij, de boekhouding van de partij. Het inlichten van de andere leden van het Coreteam over binnengekomen betalingen indien zij verantwoordelijk zijn voor de afhandeling van de reden voor die betaling.
+
+##### II.3.B3 Coördinatie:
+
+Het Coreteam coördineert de beslissingen die als partij genomen moeten worden.
+Het Coreteam brengt de activiteiten van Belgische piraten in kaart.
+Het ontwikkelen en ondersteunen van Crews, het op regelmatige basis bijwonen en organiseren van piratenevents, activiteiten en vergaderingen, het overzicht over het werk van de verschillende squads en werkgroepen.
+Het Coreteam helpt  bij het oprichten van nieuwe crews en squads.
+
+Het Coreteam ziet toe dat deze verantwoordelijkheid wordt uitgevoerd op een manier die hun het meest geschikt lijkt: Eén/enkele van hen, een partijlid extern aan het Coreteam, een professioneel iemand, een hele squad ...
+
+##### II.3.B4 De secretaris:
+
+a) houdt de notulen op vergaderingen van het Coreteam, de dagelijkse administratieve taken van de partij, het onderhouden van de ledenlijst, het organiseren van de merchandising en lidkaarten van de partij bij.
+b) beheert de database van de partij.
+
+Het Coreteam is verantwoordelijk voor de logistiek van de partij en de webshop.
+
+##### II.3.B5 Pers:
+
+Het zo snel mogelijk helpen en te woord staan van de pers, het opstellen  en ontwikkelen van documentatie over de partij voor de pers, het  stimuleren van een zo groot mogelijke media-aandacht voor de partij.
+
+Het Coreteam ziet toe dat deze verantwoordelijkheid wordt uitgevoerd op een manier die hun het meest geschikt lijkt: Eén/enkele van hen, een partijlid extern aan het coreteam, een professioneel iemand, een hele squad ...
+
+##### II.3.B6 Internationale betrekkingen:
+
+Het Coreteam zorgt voor het onderhouden van de contacten van de partij in de verschillende internationale instellingen waarvan de Piratenpartij lid is. Verder zorgt ze voor vertegenwoordigers van de Piratenpartij in die internationale instellingen, het rapporteren over en organiseren van discussie binnen de partij over die internationale instellingen.
+
+Het Coreteam ziet toe dat deze verantwoordelijkheid wordt uitgevoerd op een manier die hun het meest geschikt lijkt: Eén/enkele van hen, een partijlid extern aan het Coreteam, een professioneel iemand, een hele squad ...
+
+##### II.3.B7 IT:
+
+Het onderhoud van de IT-infrastructuur en de website, de organisatie van geschikte steminfrastructuur tussen de algemene vergaderingen door, de beveiliging van de data van de partij.
+
+Het Coreteam ziet toe dat deze verantwoordelijkheid wordt uitgevoerd op een manier die hun het meest geschikt lijkt: Eén/enkele van hen, een partijlid extern aan het Coreteam, een professioneel iemand, een hele squad ...
+
+Elke beslissing van het Coreteam moet gecommuniceerd worden naar alle piraten.
+
+#### II.3.C. Samenstelling van het Coreteam
+
+II.3.C1 De 3 regio’s moeten vertegenwoordigd zijn in het Coreteam: Vlaanderen, Wallonië en Brussel.
+
+II.3.C2 Een lid van het Coreteam is verkozen voor een periode van maximum 18 maanden.
+
+II.3.C3 Het Coreteam verkiest iedere zes maanden een derde van haar leden.
+
+### Hoofdstuk II.4. Ondersteuning
+
+II.4.1 Er wordt technische en administratieve ondersteuning gegeven aan de piraten.
+
+II.4.2 Deze ondersteuning wordt gegeven door een instantie speciaal toegewijd: de Operational Squads.
+
+II.4.3 De personen die de ondersteuning geven,
+
+a) zetten zich in om het in de praktijk brengen van de politiek zoals ze gedefinieerd is in het piratenproject, gestemd op de Algemene Vergadering, ten dienste van de piraten;
+b) hebben niet de rol om te beslissen;
+c) moeten regelmatig, in detail en volledig haar activiteiten publiceren en duidelijk maken dat alle piraten er van op de hoogte zijn.
+
+#### II.4.4 Coördinatie-squad:
+
+II.4.4.1 De Coördinatie-squad heeft de volgende exclusieve bevoegdheden:
+
+1. Inkomende email op het contactadres contact@pirateparty.be beheren. Onder "beheren" wordt verstaan het forwarden naar de juiste persoon die kan antwoorden.
+2. Beheren van een publieke lijst van crews, inclusief een contactpersoon.
+3. Beheren van een publieke lijst van lopende projecten, inclusief een contactpersoon.
+4. Oproepen van elke piraat, squad, crew, coreteam of projectvertegenwoordiger om naar informatie over hun activiteiten te vragen.
+
+II.4.4.2 De Coördinatie-squad dient als een "orakel" voor piraten. Hiermee wordt bedoeld dat iedere piraat met een bepaalde behoefte of vraag contact kan opnemen met de Coördinatie-squad. Er wordt dan van de Coördinatie-squad verwacht hem/haar in contact te brengen met de juiste piraat om hem/haar te helpen.
+
+#### II.4.5 Financiën-squad:
+
+1. De Financiën-squad heeft de volgende exclusieve bevoegdheden:
+2. Implementeren van het budget goedgekeurd door de Algemene Vergadering.
+3. Inkomsten en uitgaven moeten op elk moment zichtbaar zijn voor iedereen.
+
+#### II.4.6 Algemene Vergadering-squad:
+
+1. De AV-squad organiseert de algemene vergaderingen. De AV-squad heeft de volgende exclusieve bevoegdheden:
+2. Verzekeren dat het AV-protocol correct gevolgd wordt.
+3. Verzamelen van alle voorstellen en amendementen gemaakt door leden.
+4. Voorbereiden van alle stembrieven.
+5. Verzekeren dat de documenten vertaald zijn.
+6. Publiceren van de statuten.
+7. Verzamelen van moties van vertrouwen.
+
+#### II.4.7 IT-squad:
+
+1. De leden en enkel de leden van de IT-squad hebben toegang tot de servers van de partij, met uitzondering van de leden van de Wiki-squad, die er beperkte toegang toe hebben, zoals beschreven in de overeenkomstige sectie.
+
+#### II.4.8 Pers-squad:
+
+1. De Pers-squad heeft de volgende exclusieve bevoegdheden:
+2. Spreken in naam van de partij tot de pers.
+3. Reageren op nieuws door het publiceren van persberichten.
+
+#### II.4.9 Secretariaat-squad:
+
+1. De leden en enkel de leden van de Secretariaat-squad hebben toegang tot de database van de leden van de partij. De Secretariaat-squad heeft de volgende exclusieve bevoegdheden:
+2. Verzekeren dat de partij aan alle legale vereisten voldoet.
+3. Ze beheert de aansluiting van leden en de betalingen van het lidgeld. Ze infromeert de nieuwe leden van hun aansluiting en verstuurt persoonlijke herinneringen voor de betalingen van het lidgeld.
+
+#### II.4.10 Wiki-squad:
+
+1. De Wiki-squad beheert de wiki.
+2. De leden en enkel de leden van de Wiki-squad hebben administrator-rechten op de wiki.
+3. De leden van de Wiki-squad hebben ook toegang tot de wiki-installatie via een speciale SSH-toegang.
+
+### Hoofdstuk II.5. Algemene Vergadering
+
+II.5.1 Een stem kan als volmacht gegeven worden aan één en slechts één piraat.
+
+II.5.2 De Algemene Vergadering is bevoegd om:
+
+a) de doelen en de fundamenten vast te leggen en ze te vertalen in een politiek programma;
+b) het programma, ideologische oriëntering of organisatie van de partij;
+c) in geval van ontbinding van de feitelijke vereniging het benoemen van één of meer vereffenaars. Zij bepaalt hun bevoegdheid en, in de geest van deze statuten, de bestemming die aan het vermogen van de FV moet worden gegeven;
+d) het verkiezenen van alle verkozenen binnen de instanties van de partij op nationaal niveau;
+e) het aanpassen van de statuten;
+f) het verkiezen van de leden van het arbitragehof;
+g) het nemen van iedere beslissing volgens of in tegenspraak met de statuten;
+
+II.5.3 De algemene vergadering bestaat uit alle leden.
+
+II.5.4 De algemene vergadering komt minstens één keer per jaar samen.
+
+II.5.5 De agenda moet verstuurd worden naar alle leden zes weken voor de Algemene Vergadering gehouden wordt.
+
+II.5.6 De algemene vergadering wordt buitengewoon bijeen geroepen:
+a) op vraag van 10% van de leden;
+b) op vraag van het coreteam;
+c) voor alle verkiezingen.
+
+II.5.7 Alle internationale afspraken die de Piratenpartij aangaat zijn pas geldig na ratificatie op een Algemene vergadering. Dit bevat onder meer de relaties met PPI en PPEU
+
+### Hoofdstuk II.6. X
+
+II.6.1 X vergadert permanent online en neemt democratische beslissingen via een door haar gekozen systeem. Het eerste systeem dat daarvoor gebruikt wordt is “getOpinionated”. Dit orgaan kan op ieder moment van systeem veranderen.
+
+II.6.2 Dit orgaan is samengesteld uit alle leden van de Piratenpartij.
+
+II.6.3 Dit orgaan is bevoegd voor:
+a) wijzigingen voorstellen voor het programma van de partij.
+b) voorstellen van ideologische partijstandpunten.
+
+II.6.4 Dit orgaan heeft een algemeen evocatie- en interpellatie recht tegenover het coreteam en de leden van het coreteam.
+
+II.6.5 Dit orgaan kan leden van de fractie, de ministers/staatssecretarissen en alle andere politieke mandatarissen van de partij interpelleren over hun publieke handelingen en de standpunten die ze publiek innemen.
+
+## Deel III : Diverse verordeningen
+
+### Hoofdstuk III.1. Verkozenen en Cumuls
+
+III.1.1 De piratenvertegenwoordigers, verkozenen in de gemeenteraad, provincieraad, regionaal of federaal niveau, engageren zich om:
+
+a) het programma van de partij te respecteren;
+b) het Europese verdrag van de mensenrechten te respecteren;
+c) hun beslissingen te verdedigen bij andere piraten;
+d) in orde te zijn met hun lidgeld;
+e) deel te nemen aan de vergaderingen van hun Crew
+f) ontslag te nemen als de betrokken organisatie en het Coreteam vinden dat de verkozene onafdoende zich inspant voor de principes die hij getekend heeft
+g) zijn mandaat minstens tot het midden en liefst tot het einde uit te voeren. Dit uit respect voor zijn kiezers.
+
+III.1.2 De functies van het Coreteam zijn op elk niveau onverenigbaar. Ook het cumuleren van een politiek mandaat en een functie in het coreteam is niet toegestaan, tenzij bij mandaten in de gemeenteraad.
+
+III.1.3 De vertegenwoordigers van de piratenpartij verkozen in de gemeenteraad, provincieraad, regionaal of federaal niveau storten een deel van hun salaris: minimaal 5% op het bruto-inkomen en in functie van een barema volgens hun mandaat.
+
+III.1.4 Onverminderd andere statutaire bepalingen is het stemrecht van de mandataris geschorst bij niet-betaling van de statutaire afdrachten binnen de drie maanden volgend op de opeisbaarheid van de schuld. Vanaf het ogenblik van de schorsing van het stemrecht kan de betrokkene geen kandidaat zijn voor om het even welke verkiezing, tot op het ogenblik van de betaling van de schuld. Dezelfde regels zijn van kracht wanneer een bestuur zijn afdracht niet betaalt. In voorkomend geval wordt het stemrecht van al zijn afgevaardigden ontnomen.
+
+### Hoofdstuk III.2. Stemmingen en meerderheid
+
+III.2.1 Alle beslissingen worden genomen bij gewone meerderheid tenzij een bijzondere meerderheid is vereist.
+
+III.2.2 Een gewone meerderheid bedraagt meer dan de helft van de uitgebrachte stemmen, zonder de onthoudingen. Een bijzondere meerderheid bedraagt minstens de gulden snede van de uitgebrachte stemmen :
+
+```[100*(V5-1)]/2 % ~ 61,8%```
+
+III.2.3 Onthoudingen worden niet meegerekend voor het behalen van de meerderheid.
+
+III.2.4 Ongeldige stemmen worden nooit meegerekend.
+
+III.2.5 Indien de helft of meer dan de helft van de stemmen onthouding zijn, wordt de stemming als ongeldig beschouwd.
+
+III.2.6 Voor unanimiteit mag geen enkele piraat tegen stemmen.
+
+III.2.7 Indien een voorstel geen meerderheid haalt, is het voorstel verworpen.
+
+III.2.8 Motie van wantrouwen :
+
+III.2.8.1 Een motie van wantrouwen vereist een bijzondere meerderheid van de uitgebrachte stemmen om goedgekeurd te worden.
+
+III.2.8.2 Er zijn 3 piraten nodig om op te roepen tot een motie van wantrouwen. Voor er gestemd wordt moeten de redenen voor de motie duidelijk vermeld worden door de personen die ertoe oproepen.
+
+### Hoofdstuk III.3. Lijstvorming
+
+III.3.1  Om zich kandidaat te stellen bij gemeenschaps-, gewestelijke, nationale of Europese verkiezingen moet men lid zijn van de Piratenpartij.
+
+III.3.2 Elke kandidaat moet de kans krijgen zijn kandidatuur persoonlijk te verdedigen.
+
+III.3.3 Kandidaturen kunnen worden ingediend voor elke plaats op de lijst. Bij elke kandidatuur moet worden vermeld op welke plaats(en) op de lijst ze betrekking heeft.
+
+III.3.4 Er wordt eerst een kandidatenlijst gemaakt van deze kandidaten, onafhankelijk van de plaats(en) waarop ze van toepassing is. Vervolgens wordt over de hele kandidatenlijst zowel een approval voting als een Condorcet-Schulze rangschikking gemaakt. Alle leden van de Piratenpartij die op de juiste plaats wonen om op de lijst te kunnen staan hebben hierin stemrecht.
+
+III.3.5 Alle kandidaten in de rangschikking die geen gewone meerderheid hebben in de approval voting, worden geschrapt uit de rangschikking.
+
+III.3.6 Indien verschillende kandidaten gelijk gerangschikt staan in de rangschikking, dan wordt de besloten welke kandidaat hoger gerangschikt staat aan de hand van een spelletje geblinddoekt blad-steen-schaar.
+
+III.3.7 De lijst wordt van boven naar onder doorlopen. Voor iedere plaats op de lijst krijgt de hoogst gerangschikte kandidaat in de rangschikking die zijn kandidatuur voor de plaats(en) stelde en die nog niet in de lijst voorkomt de plaats.
+
+III.3.8 Indien na het doorlopen van alle plaatsen op de lijst er nog kandidaten in de rangschikking zijn die niet op de lijst voorkomen, dan kunnen deze hun plaats(en) waarop hun kandidatuur betrekking heeft nog 1 maal aanpassen waarna teruggegaan wordt naar stap 3.
+
+III.3.9 Indien na het doorlopen van de plaatsen op de lijst nog plaatsen op de lijst zijn waarvoor er geen kandidaten zijn, dan worden alle onderliggende kandidaten op de lijst een plaats doorgeschoven naar boven.
+
+III.3.10 Indien na het opstellen van de lijsten er kandidaten op de lijst staan die niet op de lijst wensen te staan, dan worden deze van de lijst gehaald en schuiven alle onderliggende kandidaten een plaats naar boven.
+
+III.3.11 Indien na dit proces een lijst is ontstaan die omwille van de geslachten van de deelnemers op de lijst niet wettelijk is, dan worden de vrouwen naar boven geschoven en de mannen onderaan de lijst geschrapt tot de lijst wettelijk in orde is, of vice-versa. Daarna wordt weer teruggekeerd naar stap 5. Indien de lijst wettelijk in orde is, is de lijst definitief.
+
+III.3.12 Indien alle kandidaten die hun kandidatuur ingediend hebben unaniem akkoord gaan met een andere methode om de lijst op te stellen, of unaniem akkoord gaan met een lijst, dan kan van deze methode afgeweken worden.
+
+### Hoofdstuk III.4. Verzamelingen van Crews
+
+III.4.1 Een vloot is een tijdelijke en vrijwillige samenkomst van minimaal twee Crews, verzamelt rond een gemeenschappelijk en/of precies doel. De beslissing om een vloot te creëeren moet deel uitmaken van een formele beslissing in iedere Crew die deel uitmaakt van de vloot.
+
+III.4.2 Leden van een vloot zijn de leden van de Crews waaruit ze bestaat.
+
+III.4.3 De deelname aan een vloot moet deel uitmaken van een akkoord vooraf van de Crew (opt-in).
+
+III.4.4 Met respect voor de statuten en met respect voor de algemene doelen van de partij, beslist een vloot intern over haar manier van werken alsook over de acties die ze uitvoert.
+
+III.4.5 Een vloot wordt ontbonden als : het doel bereikt is ze slechts uit een enkele Crew bestaat.
+
+### Hoofdstuk III.5: Conflictresolutie
+
+#### III.5.1 Moderatie
+
+III.5.1.1 Squads die verantwoordelijk zijn voor de digitale communicatiekanalen van de partij, hebben het recht om die kanalen te modereren, en indien nodig, mensen de toegang tot die kanalen te ontzeggen. De moderatie en het uitsluiten van een kanaal moet gebaseerd zijn op de overtreding op een gebruikscharter, om arbitrariteit te vermijden. Deze moet vooraf vastgelegd zijn of gebaseerd zijn op een bestaand charter.
+
+III.5.1.2 Dit gebruikscharter moet goedgekeurd worden op een algemene vergadering.
+
+#### III.5.2 Verzoenings- en tuchtcommissie
+
+III.5.2.1 Het gezag van de algemene vergadering moet door alle leden worden aanvaard en geëerbiedigd. Personen die het gezag van de algemene vergadering ondermijnen, die weigeren zich neer te legen bij definitieve bestuursbeslissingen of door hun gedrag of houding de partij in opspraak brengen of schade berokkenen, kunnen in hun functies geschorst worden.
+
+III.5.2.2 Organen die het gezag van de algemene vergadering niet kunnen accepteren of die acties ondernemen die de partij in opspraak brengen of schade berokkenen, kunnen collectief geschorst worden.
+
+III.5.2.3 Een schorsing van organen of personen kan door een verzoenings- en tuchtprocedure, die  door minimum 3 piraten gestart worden tegen dit bestuur en die persoon.
+
+III.5.2.4 Het Coreteam bepaalt de betrokken partijen bij een verzoenings- en tuchtprocedure.
+
+III.5.2.5 Het Coreteam kan tijdelijk een of meer betrokken partijen schorsen voor een maximum van twee maanden, of tot het einde van de procedure indien dit eerder is.
+
+III.5.2.6 Het Coreteam stelt een conflictresolutie-groep samen, bestaande uit:
+
+* 5 willekeurig geselecteerde leden van de Piratenpartij die tijdens de laatste AV aanwezig waren. Als een geselecteerde Piraat de uitnodiging afslaat, zal een vervanger worden gevonden.
+* Leden van het Coreteam en betrokken partijen in het conflict worden automatisch uitgesloten.
+* De conflictresolutie-groep bevat minimaal 2 sprekers van de taal van de betrokken partijen.
+
+III.5.2.7 De conflictresolutie-groep kan beslissen om het conflict niet te behandelen, in het geval het frivool wordt geacht of op andere wijze irrelevant is geworden.
+
+III.5.2.8 De conflictresolutie-groep moet proberen om het conflict op te lossen door bemiddeling tussen de betrokken partijen. De bemiddeling wordt als succesvol beschouwd als alle betrokken partijen overeenkomen.
+
+III.5.2.9 Alleen met goedkeuring van het Coreteam kan een schorsing uitgesproken worden tijdens de periode van zes maanden die voorafgaat aan de datum van politieke verkiezingen. Anders wordt die beslissing over de verkiezingen getild.
+
+III.5.2.10 Alle aanhangig gemaakte klachten en elementen worden publiek en transparant behandeld, maar met respect voor de privacy van de betrokkenen.
+
+III.5.2.11 De conflictresolutie-groep kan uiteindelijk besluiten om:
+
+* Eén of meerdere partijen een formele berisping te geven, ofwel intern (met de betrokken partijen), ofwel openbaar binnen de partij.
+* Eén of meerdere partijen uit hun huidige functie(s) binnen de partij te zetten.
+* Eén of meerdere partijen te schorsen, voor een maximale duur van 12 maanden.
+* Eén of meer partijen uit de Belgische Piratenpartij en al haar activiteiten uit te sluiten.
+
+III.5.2.12 De verzoenings- en tuchtcommissie beslist bij 4 van de 5 stemmen of meer.
+
+III.5.2.13 De vraag tot wederopneming van een eerder uitgesloten lid wordt door het uitgesloten lid zelf via schrijven aan de algemene vergadering voorleggen. De algemene vergadering kan beslissen om de zaak aan te nemen, hoort vervolgens het uitgesloten lid en eventueel andere betrokken partijen en neemt de beslissing.
+
+## Deel IV : Aanhangsels
+
+### Prague Declaration, 17.04.2012
+
+The assembled European Pirates signed below agreed on the following:
+
+#### I.
+
+We intend to run in the elections to the European Parliament in the year 2014.
+
+#### II.
+
+We declare the intent to have a common election program included in the individual programs of the respective parties, to coordinate our election campaigns, to cooperate closely in the European Parliament on the realisation of our common program.
+
+#### III.
+
+The common program shall consist of components regarding European policies that have been approved by participating parties.
+
+Every participating party will be able to set forth its opinion and report the state of its procedure regarding every proposal.
+
+#### IV.
+
+We agree to establish a political party at European level [Regulation (EC) No 2004/2003 of the European Parliament and of the Council of 4 November 2003, as later amended].
+
+#### V.
+
+We propose this declaration for ratification to the competent bodies of the European Pirate Parties.
+
+### Paris Declaration, 20.02.2013
+
+Purpose of the organization is to represent the European Pirate movement towards the European institutions and to work in the interest of its members by, amongst other things:
+
+* Facilitating coordination and cooperation between its members.
+* Assisting its members to promote the Pirate movement in Europe.
+* Taking as its principles the Pirate manifesto, as will be annexed to the statutes.
+* Functioning as a link between European Pirate Parties and Pirate MEPs.
+* Encouraging and supporting its members in organizing events focused on European topics


### PR DESCRIPTION
There are still some issues with the statutes' hierarchy. For instance, paragraphs
are set on a 4th level, but sometimes they actually are on a 3rd level
(so they are displayed like this: 1.2.0.1, 1.2.0.2, ... instead of
1.2.1, 1.2.2, ...).

When this will be fixed, we will have to remove the hard-coded numbering.

By the way, I put statutes locally, in a directory (assets/statutes/)
for testing purposes.
